### PR TITLE
Feat/menu mobile

### DIFF
--- a/src/components/MenuItem/index.tsx
+++ b/src/components/MenuItem/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Link } from '@material-ui/core';
+import { Link, ListItem, ListItemText } from '@material-ui/core';
 
 import { useStyles } from './styles';
 
@@ -20,6 +20,14 @@ export interface MenuItemProps {
    * The boolean value used to determine some internal link props
    */
   external?: boolean;
+  /**
+   * The boolean value used to determine desktop or mobile styles
+   */
+  mobile?: boolean;
+  /**
+   * Callback used to close the drawer on mobile
+   */
+  onClose?: any;
 }
 
 export const MenuItem: FC<MenuItemProps> = ({
@@ -27,18 +35,24 @@ export const MenuItem: FC<MenuItemProps> = ({
   label,
   component,
   external,
+  mobile,
+  onClose,
 }: MenuItemProps) => {
-  const classes = useStyles();
+  const classes = useStyles(mobile);
 
-  const hrefProps = external ? { href: to } : { to };
+  const hrefProps = external
+    ? { href: to, target: '_blank', rel: 'noopener noreferrer' }
+    : { to, target: '_self' };
 
-  return (
+  return mobile ? (
+    <ListItem {...hrefProps} component={component} onClick={onClose} button>
+      <ListItemText primary={label} />
+    </ListItem>
+  ) : (
     <Link
       {...hrefProps}
-      target={external ? '_blank' : '_self'}
-      rel={external ? 'noopener noreferrer' : undefined}
       component={component}
-      className={classes.link}
+      className={!mobile && classes.link}
       underline="none"
     >
       {label}
@@ -48,6 +62,7 @@ export const MenuItem: FC<MenuItemProps> = ({
 
 MenuItem.defaultProps = {
   component: 'a',
+  mobile: false,
 };
 
 MenuItem.displayName = 'MenuItem';

--- a/src/components/MenuMobile/index.tsx
+++ b/src/components/MenuMobile/index.tsx
@@ -6,15 +6,36 @@ import MenuItem from '../MenuItem';
 import { useStyles } from './styles';
 
 interface MenuItem {
+  /**
+   * The path of menu item link
+   */
   slug: string;
+  /**
+   * The label to display on link
+   */
   label: string;
+  /**
+   * The component used by the link
+   */
   component?: any;
+  /**
+   * A boolean to mark a link like external
+   */
   external?: boolean;
 }
 
 export interface MenuMobileProps {
+  /**
+   * A boolean flag used to open/close the menu
+   */
   open: boolean;
+  /**
+   * Function to toggle the open flag
+   */
   toggleMenu: any;
+  /**
+   * The menu list items
+   */
   menu: any;
 }
 
@@ -26,35 +47,33 @@ export const MenuMobile: FC<MenuMobileProps> = ({
   const classes = useStyles();
 
   return (
-    <>
-      <Hidden only={['md', 'lg', 'xl']} implementation="css">
-        <IconButton onClick={toggleMenu}>
-          <MenuRoundedIcon color="secondary" />
-        </IconButton>
-        <Drawer
-          anchor="left"
-          open={open}
-          variant="temporary"
-          onClose={toggleMenu}
-        >
-          <List className={classes.list}>
-            {menu.map(
-              ({ slug, label, component, external }: MenuItem, idx: string) => (
-                <MenuItem
-                  key={`menu_${idx}`}
-                  to={slug}
-                  label={label}
-                  component={component}
-                  external={external}
-                  onClose={toggleMenu}
-                  mobile
-                />
-              )
-            )}
-          </List>
-        </Drawer>
-      </Hidden>
-    </>
+    <Hidden only={['md', 'lg', 'xl']} implementation="css">
+      <IconButton onClick={toggleMenu}>
+        <MenuRoundedIcon color="secondary" />
+      </IconButton>
+      <Drawer
+        anchor="left"
+        open={open}
+        variant="temporary"
+        onClose={toggleMenu}
+      >
+        <List className={classes.list}>
+          {menu.map(
+            ({ slug, label, component, external }: MenuItem, idx: string) => (
+              <MenuItem
+                key={`menu_${idx}`}
+                to={slug}
+                label={label}
+                component={component}
+                external={external}
+                onClose={toggleMenu}
+                mobile
+              />
+            )
+          )}
+        </List>
+      </Drawer>
+    </Hidden>
   );
 };
 

--- a/src/components/MenuMobile/index.tsx
+++ b/src/components/MenuMobile/index.tsx
@@ -1,0 +1,63 @@
+import React, { FC } from 'react';
+import { Drawer, Hidden, IconButton, List } from '@material-ui/core';
+import MenuRoundedIcon from '@material-ui/icons/MenuRounded';
+
+import MenuItem from '../MenuItem';
+import { useStyles } from './styles';
+
+interface MenuItem {
+  slug: string;
+  label: string;
+  component?: any;
+  external?: boolean;
+}
+
+export interface MenuMobileProps {
+  open: boolean;
+  toggleMenu: any;
+  menu: any;
+}
+
+export const MenuMobile: FC<MenuMobileProps> = ({
+  open,
+  toggleMenu,
+  menu,
+}: MenuMobileProps) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <Hidden only={['md', 'lg', 'xl']} implementation="css">
+        <IconButton onClick={toggleMenu}>
+          <MenuRoundedIcon color="secondary" />
+        </IconButton>
+        <Drawer
+          anchor="left"
+          open={open}
+          variant="temporary"
+          onClose={toggleMenu}
+        >
+          <List className={classes.list}>
+            {menu.map(
+              ({ slug, label, component, external }: MenuItem, idx: string) => (
+                <MenuItem
+                  key={`menu_${idx}`}
+                  to={slug}
+                  label={label}
+                  component={component}
+                  external={external}
+                  onClose={toggleMenu}
+                  mobile
+                />
+              )
+            )}
+          </List>
+        </Drawer>
+      </Hidden>
+    </>
+  );
+};
+
+MenuMobile.displayName = 'MenuMobile';
+
+export default MenuMobile;

--- a/src/components/MenuMobile/styles.ts
+++ b/src/components/MenuMobile/styles.ts
@@ -1,0 +1,7 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles((theme) => ({
+  list: {
+    width: 250,
+  },
+}));

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,4 +6,5 @@ export * from './components/Hero';
 export * from './components/ContactForm';
 export * from './components/MenuItem';
 export * from './components/PostCard';
+export * from './components/MenuMobile';
 export * from './theme';

--- a/stories/Header.stories.mdx
+++ b/stories/Header.stories.mdx
@@ -26,11 +26,12 @@ import { Header } from '@blackbox-vision/ui-components';
 
 import LogoComponent from './LogoComponent';
 import MenuComponent from './MenuComponent';
+import { menuItems } from './utils/items';
 
 export const MyHeader = () => (
   <Header>
     <LogoComponent />
-    <MenuComponent />
+    <MenuComponent menu={menuItems} />
   </Header>
 );
 

--- a/stories/MenuMobile.stories.mdx
+++ b/stories/MenuMobile.stories.mdx
@@ -1,0 +1,49 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { withKnobs, text, number } from '@storybook/addon-knobs';
+
+import { addThemeProvider } from './utils/decorators/theme';
+import { MenuMobileSample } from './utils/components/MenuMobileSample';
+import { menuItems } from './utils/items';
+import { MenuMobile, theme } from '../src';
+
+<Meta title="UI Components/MenuMobile" component={MenuMobile} />
+
+# MenuMobile
+
+Stories related to **MenuMobile** component.
+
+## Example
+
+This is how you can use **MenuMobile** component:
+
+```jsx
+import React from 'react';
+import { MenuMobile } from '@blackbox-vision/ui-components';
+import { menuItems } from './utils/items';
+
+export const MyMenuMobile = () => {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <MenuMobile open={open} menu={menuItems} onClose={() => setOpen(false)} />
+  );
+};
+
+MyMenuMobile.displayName = 'MyMenuMobile';
+```
+
+## Live Preview
+
+Here you can see the **MenuMobile** component in action:
+
+<Preview withSource="none">
+  <Story name="Get started" decorators={[withKnobs, addThemeProvider(theme)]}>
+    <MenuMobileSample initialOpen={true} />
+  </Story>
+</Preview>
+
+## MenuMobile Props
+
+Here you can see the props for the **MenuMobile** component:
+
+<Props of={MenuMobile} />

--- a/stories/PostCard.stories.mdx
+++ b/stories/PostCard.stories.mdx
@@ -68,7 +68,11 @@ Here you can see the **PostCard** component in action:
   >
     <Switch>
       <Route exact path="/">
-        <Link to="/halving-a-react-qr-reader-bundle-size">
+        <Link
+          to="/halving-a-react-qr-reader-bundle-size"
+          underline="none"
+          style={{ textDecoration: 'none' }}
+        >
           <Grid container>
             <Grid xs={false} sm={6} md={4} item />
             <Grid xs={12} sm={6} md={4} item>

--- a/stories/utils/components/MenuComponent.tsx
+++ b/stories/utils/components/MenuComponent.tsx
@@ -1,58 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
-import {
-  Button,
-  Drawer,
-  Hidden,
-  List,
-  ListItem,
-  ListItemText,
-  IconButton,
-} from '@material-ui/core';
-import MenuRoundedIcon from '@material-ui/icons/MenuRounded';
+import { Button, Hidden } from '@material-ui/core';
 
-interface MenuItem {
-  slug: string;
-  label: string;
-  target?: string;
-  rel?: string;
-}
-
-export const MenuMobile = ({ menu }: any) => {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <Hidden only={['md', 'lg', 'xl']} implementation="css">
-      <IconButton onClick={() => setOpen(true)}>
-        <MenuRoundedIcon color="secondary" />
-      </IconButton>
-      <Drawer
-        anchor="left"
-        open={open}
-        variant="temporary"
-        onClose={() => setOpen(false)}
-      >
-        <List>
-          {menu.map(
-            ({ slug, label, target = '_self', rel }: MenuItem, idx: string) => (
-              <ListItem
-                key={`menu_${idx}`}
-                to={slug}
-                target={target}
-                rel={rel}
-                component={Link}
-                onClick={() => setOpen(false)}
-                button
-              >
-                <ListItemText primary={label} />
-              </ListItem>
-            )
-          )}
-        </List>
-      </Drawer>
-    </Hidden>
-  );
-};
+import { MenuMobileSample } from './MenuMobileSample';
 
 export const MenuComponent = ({ menu }: any) => (
   <>
@@ -60,7 +10,7 @@ export const MenuComponent = ({ menu }: any) => (
       <nav>
         {menu &&
           menu.map(
-            ({ slug, label, target = '_self', rel }: MenuItem, idx: string) => (
+            ({ slug, label, target = '_self', rel }: any, idx: string) => (
               <Button
                 key={`menu_${idx}`}
                 to={slug}
@@ -74,6 +24,6 @@ export const MenuComponent = ({ menu }: any) => (
           )}
       </nav>
     </Hidden>
-    <MenuMobile menu={menu} />
+    <MenuMobileSample />
   </>
 );

--- a/stories/utils/components/MenuMobileSample.tsx
+++ b/stories/utils/components/MenuMobileSample.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { IconButton, Hidden } from '@material-ui/core';
+import MenuRoundedIcon from '@material-ui/icons/MenuRounded';
+
+import { menuItems } from '../items';
+import { MenuMobile } from '../../../src';
+export const MenuMobileSample = ({ initialOpen = false }: any) => {
+  const [open, setOpen] = useState(initialOpen);
+
+  return (
+    <>
+      <Hidden only={['xs', 'sm']}>
+        Resize your viewport to see the <strong>Hamburger</strong> button →
+      </Hidden>
+      <Hidden only={['xs', 'sm', 'md']}>
+        <IconButton onClick={() => setOpen(!open)}>
+          <MenuRoundedIcon color="secondary" />
+        </IconButton>
+      </Hidden>
+      <MenuMobile
+        open={open}
+        toggleMenu={() => setOpen(!open)}
+        menu={menuItems}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
# Summary

- Added a `MenuMobile` component and use on the other stories
- Added a story example with docs
- Fix the Link underline text-decoration styles
- Refactor of `MenuItem` to support mobile MUI `ListItem` components
- Add responsive examples using MUI `Hidden` component